### PR TITLE
feat(backend): add Perplexity search integration

### DIFF
--- a/autogpt_platform/backend/backend/blocks/perplexity/_auth.py
+++ b/autogpt_platform/backend/backend/blocks/perplexity/_auth.py
@@ -1,0 +1,34 @@
+from typing import Literal
+
+from pydantic import SecretStr
+
+from backend.data.model import APIKeyCredentials, CredentialsField, CredentialsMetaInput
+from backend.integrations.providers import ProviderName
+
+PerplexityCredentials = APIKeyCredentials
+PerplexityCredentialsInput = CredentialsMetaInput[
+    Literal[ProviderName.PERPLEXITY],
+    Literal["api_key"],
+]
+
+TEST_CREDENTIALS = APIKeyCredentials(
+    id="01234567-89ab-cdef-0123-456789abcdef",
+    provider="perplexity",
+    api_key=SecretStr("mock-perplexity-api-key"),
+    title="Mock Perplexity API key",
+    expires_at=None,
+)
+
+TEST_CREDENTIALS_INPUT = {
+    "provider": TEST_CREDENTIALS.provider,
+    "id": TEST_CREDENTIALS.id,
+    "type": TEST_CREDENTIALS.type,
+    "title": TEST_CREDENTIALS.title,
+}
+
+
+def PerplexityCredentialsField() -> PerplexityCredentialsInput:
+    """Creates a Perplexity credentials input on a block."""
+    return CredentialsField(
+        description="The Perplexity integration requires an API Key."
+    )

--- a/autogpt_platform/backend/backend/blocks/perplexity/search.py
+++ b/autogpt_platform/backend/backend/blocks/perplexity/search.py
@@ -1,0 +1,56 @@
+from backend.blocks.perplexity._auth import (
+    PerplexityCredentials,
+    PerplexityCredentialsField,
+    PerplexityCredentialsInput,
+)
+from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
+from backend.data.model import SchemaField
+from backend.util.request import requests
+
+
+class PerplexitySearchBlock(Block):
+    class Input(BlockSchema):
+        credentials: PerplexityCredentialsInput = PerplexityCredentialsField()
+        query: str = SchemaField(description="The search query")
+        number_of_results: int = SchemaField(
+            description="Number of results to return",
+            default=10,
+            advanced=True,
+        )
+
+    class Output(BlockSchema):
+        results: list = SchemaField(
+            description="List of search results",
+            default_factory=list,
+        )
+        error: str = SchemaField(description="Error message if the request failed")
+
+    def __init__(self):
+        super().__init__(
+            id="676f67ce-04d7-4c42-b917-bc2b4f7d66bf",
+            description="Searches the web using Perplexity's search API",
+            categories={BlockCategory.SEARCH},
+            input_schema=PerplexitySearchBlock.Input,
+            output_schema=PerplexitySearchBlock.Output,
+        )
+
+    def run(
+        self, input_data: Input, *, credentials: PerplexityCredentials, **kwargs
+    ) -> BlockOutput:
+        url = "https://api.perplexity.ai/search"
+        headers = {
+            "Authorization": f"Bearer {credentials.api_key.get_secret_value()}",
+        }
+
+        params = {
+            "q": input_data.query,
+            "n": input_data.number_of_results,
+        }
+
+        try:
+            response = requests.get(url, headers=headers, params=params)
+            response.raise_for_status()
+            data = response.json()
+            yield "results", data.get("results", [])
+        except Exception as e:
+            yield "error", str(e)

--- a/autogpt_platform/backend/backend/integrations/credentials_store.py
+++ b/autogpt_platform/backend/backend/integrations/credentials_store.py
@@ -116,6 +116,13 @@ exa_credentials = APIKeyCredentials(
     title="Use Credits for Exa search",
     expires_at=None,
 )
+perplexity_credentials = APIKeyCredentials(
+    id="543cff70-2c6f-4ae2-804e-fa63af377db3",
+    provider="perplexity",
+    api_key=SecretStr(settings.secrets.perplexity_api_key),
+    title="Use Credits for Perplexity search",
+    expires_at=None,
+)
 e2b_credentials = APIKeyCredentials(
     id="78d19fd7-4d59-4a16-8277-3ce310acf2b7",
     provider="e2b",
@@ -199,6 +206,7 @@ DEFAULT_CREDENTIALS = [
     open_router_credentials,
     fal_credentials,
     exa_credentials,
+    perplexity_credentials,
     e2b_credentials,
     mem0_credentials,
     nvidia_credentials,
@@ -266,6 +274,8 @@ class IntegrationCredentialsStore:
             all_credentials.append(fal_credentials)
         if settings.secrets.exa_api_key:
             all_credentials.append(exa_credentials)
+        if settings.secrets.perplexity_api_key:
+            all_credentials.append(perplexity_credentials)
         if settings.secrets.e2b_api_key:
             all_credentials.append(e2b_credentials)
         if settings.secrets.nvidia_api_key:

--- a/autogpt_platform/backend/backend/integrations/providers.py
+++ b/autogpt_platform/backend/backend/integrations/providers.py
@@ -38,6 +38,7 @@ class ProviderName(str, Enum):
     SMARTLEAD = "smartlead"
     SMTP = "smtp"
     TWITTER = "twitter"
+    PERPLEXITY = "perplexity"
     TODOIST = "todoist"
     UNREAL_SPEECH = "unreal_speech"
     ZEROBOUNCE = "zerobounce"

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -420,6 +420,7 @@ class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
 
     fal_api_key: str = Field(default="", description="FAL API key")
     exa_api_key: str = Field(default="", description="Exa API key")
+    perplexity_api_key: str = Field(default="", description="Perplexity API key")
     e2b_api_key: str = Field(default="", description="E2B API key")
     nvidia_api_key: str = Field(default="", description="Nvidia API key")
     mem0_api_key: str = Field(default="", description="Mem0 API key")


### PR DESCRIPTION
## Changes
- add `PERPLEXITY` provider name
- support `perplexity_api_key` secret
- manage Perplexity credentials in store
- implement `PerplexitySearchBlock`

## Testing
- `poetry run format` *(fails: pyright missing Prisma imports)*
- `poetry run test` *(fails: FileNotFoundError: 'docker')*


------
https://chatgpt.com/codex/tasks/task_e_684bf3682a748321ad177aed96507a8a